### PR TITLE
Update hipchat script to support apiv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ E.G:
 export HIPCHAT_TOKEN=<token>
 export HIPCHAT_ROOM_ID=<room_id>
 export HIPCHAT_NOTIFY=1
-export HIPCHAT_FROM='Dokku'
-
+export HIPCHAT_FROM='Dokku' # optional in v2
+export HIPCHAT_API=v1       # version should be v1 or v2
 ```
 
 see <https://github.com/hipchat/hipchat-cli#environment-variables> for more details.

--- a/hipchat
+++ b/hipchat
@@ -35,6 +35,7 @@ OPTIONS:
    -l <level>     Nagios message level (critical, warning, unknown, ok, down, up). Will override color.
    -n             Trigger notification for people in the room
    -o             API host (api.hipchat.com)
+   -v <version>   API version (default: v1)
 EOF
 }
 
@@ -44,13 +45,14 @@ test -f /etc/hipchat && . /etc/hipchat
 TOKEN=${HIPCHAT_TOKEN:-}
 ROOM_ID=${HIPCHAT_ROOM_ID:-}
 FROM=${HIPCHAT_FROM:-}
-COLOR=${HIPCHAT_COLOR:-}
+COLOR=${HIPCHAT_COLOR:-yellow}
 FORMAT=${HIPCHAT_FORMAT:-html}
 MESSAGE=${HIPCHAT_MESSAGE:-html}
 NOTIFY=${HIPCHAT_NOTIFY:-0}
 HOST=${HIPCHAT_HOST:-api.hipchat.com}
 LEVEL=${HIPCHAT_LEVEL:-}
-while getopts “ht:r:f:c:m:o:i:l:n” OPTION; do
+API=${HIPCHAT_API:-v1}
+while getopts “ht:r:f:c:m:o:i:l:v:n” OPTION; do
   case $OPTION in
     h) usage; exit 1;;
     t) TOKEN=$OPTARG;;
@@ -62,6 +64,7 @@ while getopts “ht:r:f:c:m:o:i:l:n” OPTION; do
     i) INPUT=$OPTARG;;
     l) LEVEL=$OPTARG;;
     o) HOST=$OPTARG;;
+    v) API=$OPTARG;;
     [?]) usage; exit;;
   esac
 done
@@ -103,9 +106,27 @@ fi
 INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\"|href=')((?:https?|ftp|mailto)\:\/\/[^ \n]*)/\<a href=\"\1\"\>\1\<\/a>/g")
 
 # urlencode with perl
-INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')
+if [ $API == 'v1' ]; then
+  INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')
+fi
+
+# replace notification boolean from 1/0 to 'true'/'false' for API v2
+if [ $API == 'v2' ]; then
+  if [ $NOTIFY -eq 0 ]; then
+    NOTIFY='false'
+  else
+    NOTIFY='true'
+  fi
+fi
 
 # do the curl
-curl -sS \
-  -d "auth_token=$TOKEN&room_id=$ROOM_ID&from=$FROM&color=$COLOR&message_format=$FORMAT&message=$INPUT&notify=$NOTIFY" \
-  https://$HOST/v1/rooms/message
+if [ $API == 'v2' ]; then
+  curl -sS \
+    -H 'Content-type: application/json' \
+    -d "{\"color\":\"$COLOR\", \"message\":\"$INPUT\", \"message_format\":\"$FORMAT\", \"notify\":$NOTIFY}" \
+    https://$HOST/v2/room/$ROOM_ID/notification?auth_token=$TOKEN
+else
+  curl -sS \
+    -d "auth_token=$TOKEN&room_id=$ROOM_ID&from=$FROM&color=$COLOR&message_format=$FORMAT&message=$INPUT&notify=$NOTIFY" \
+    https://$HOST/v1/rooms/message
+fi

--- a/post-build
+++ b/post-build
@@ -2,4 +2,4 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
 echo "-----> Notifying Hipchat of Release ..."
-echo "Build Complete for $APP on $HOSTNAME (<a href='http://$APP.$HOSTNAME'>$APP.$HOSTNAME</a>)" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "Build Complete for $APP on $HOSTNAME" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null

--- a/post-build
+++ b/post-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
-echo "-----> Notifying Hipchat of Release ..."
-echo "Build Complete for $APP on $HOSTNAME" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "-----> Notifying HipChat of release ..."
+echo "Build complete for <strong>$APP</strong> on $HOSTNAME." | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null

--- a/post-build
+++ b/post-build
@@ -2,4 +2,4 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
 echo "-----> Notifying Hipchat of Release ..."
-echo "Build Complete for $APP on $HOSTNAME" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "Build Complete for $APP on $HOSTNAME (<a href='http://$APP.$HOSTNAME'>$APP.$HOSTNAME</a>)" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null

--- a/post-deploy
+++ b/post-deploy
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
-echo "-----> Notifying Hipchat ..."
-echo "Deployed $APP to $HOSTNAME (<a href='http://$APP.$HOSTNAME'>$APP.$HOSTNAME</a>)" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "-----> Notifying HipChat ..."
+echo "Deployed <strong>$APP</strong> to <a href='http://$APP.$HOSTNAME'>$APP.$HOSTNAME</a>." | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null

--- a/post-deploy
+++ b/post-deploy
@@ -2,4 +2,4 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
 echo "-----> Notifying Hipchat ..."
-echo "Deployed $APP to $HOSTNAME" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "Deployed $APP to $HOSTNAME (<a href='http://$APP.$HOSTNAME'>$APP.$HOSTNAME</a>)" | HIPCHAT_COLOR=green $PLUGIN_PATH/hipchat/hipchat >/dev/null

--- a/pre-build
+++ b/pre-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
-echo "-----> Notifying Hipchat ..."
-echo "Starting Build for $APP on $HOSTNAME" | HIPCHAT_COLOR=yellow $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "-----> Notifying HipChat ..."
+echo "Starting build for <strong>$APP</strong> on $HOSTNAME ..." | HIPCHAT_COLOR=yellow $PLUGIN_PATH/hipchat/hipchat >/dev/null

--- a/pre-deploy
+++ b/pre-deploy
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="$2";HOSTNAME=$(hostname -f);
-echo "-----> Notifying Hipchat ..."
-echo "Deploying $APP to $HOSTNAME" | HIPCHAT_COLOR=yellow $PLUGIN_PATH/hipchat/hipchat >/dev/null
+echo "-----> Notifying HipChat ..."
+echo "Deploying <strong>$APP</strong> to $HOSTNAME ..." | HIPCHAT_COLOR=yellow $PLUGIN_PATH/hipchat/hipchat >/dev/null


### PR DESCRIPTION
This PR update the hipchat script to upstream so that APIv2 token can be used.
